### PR TITLE
Generate sitemap and robots.txt

### DIFF
--- a/worker.js
+++ b/worker.js
@@ -43,7 +43,7 @@ addEventListener("fetch", event => {
 });
 
 function generateSitemap() {
-  sitemap = '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">';
+  let sitemap = '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">';
   slugs.forEach(
     (slug) =>
       (sitemap +=

--- a/worker.js
+++ b/worker.js
@@ -42,6 +42,17 @@ addEventListener("fetch", event => {
   event.respondWith(fetchAndApply(event.request));
 });
 
+function generateSitemap() {
+  sitemap = '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">';
+  slugs.forEach(
+    (slug) =>
+      (sitemap +=
+        "<url><loc>https://" + MY_DOMAIN + "/" + slug + "</loc></url>")
+  );
+  sitemap += "</urlset>";
+  return sitemap;
+}
+
 const corsHeaders = {
   "Access-Control-Allow-Origin": "*",
   "Access-Control-Allow-Methods": "GET, HEAD, POST, PUT, OPTIONS",
@@ -73,6 +84,14 @@ async function fetchAndApply(request) {
     return handleOptions(request);
   }
   let url = new URL(request.url);
+  if (url.pathname === "/robots.txt") {
+    return new Response("Sitemap: https://" + MY_DOMAIN + "/sitemap.xml");
+  }
+  if (url.pathname === "/sitemap.xml") {
+    let response = new Response(generateSitemap());
+    response.headers.set("content-type", "application/xml");
+    return response;
+  }
   const notionUrl = "https://www.notion.so" + url.pathname;
   let response;
   if (url.pathname.startsWith("/app") && url.pathname.endsWith("js")) {


### PR DESCRIPTION
Thanks for launching this project! It is exciting so see how fast it grew from Twitter and Producthunt.

To make the named pages more accessible for crawlers I added a function to generate a sitemap based on the slugs. To make the crawlers pick up the sitemap, I added a robots.txt referencing the sitemap.

As I think that most people using this project want to have their page indexed, this could be the default behavior. Otherwise, an additional setting to turn on/off the sitemap generation might be required.