### PR TITLE
Adding support for spaces in Font names

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+.DS_Store

--- a/src/code.js
+++ b/src/code.js
@@ -163,8 +163,8 @@ ${slugs
   class HeadRewriter {
     element(element) {
       if (GOOGLE_FONT !== '') {
-        element.append(\`<link href="https://fonts.googleapis.com/css?family=\${GOOGLE_FONT}:Regular,Bold,Italic&display=swap" rel="stylesheet">
-        <style>* { font-family: \${GOOGLE_FONT} !important; }</style>\`, {
+        element.append(\`<link href="https://fonts.googleapis.com/css?family=\${GOOGLE_FONT.replace(' ', '+')}:Regular,Bold,Italic&display=swap" rel="stylesheet">
+        <style>* { font-family: "\${GOOGLE_FONT}" !important; }</style>\`, {
          html: true
         });
       }

--- a/worker.js
+++ b/worker.js
@@ -172,8 +172,8 @@ class HeadRewriter {
   element(element) {
     if (GOOGLE_FONT !== "") {
       element.append(
-        `<link href='https://fonts.googleapis.com/css?family=${GOOGLE_FONT}:Regular,Bold,Italic&display=swap' rel='stylesheet'>
-        <style>* { font-family: ${GOOGLE_FONT} !important; }</style>`,
+        `<link href='https://fonts.googleapis.com/css?family=${GOOGLE_FONT.replace(' ', '+')}:Regular,Bold,Italic&display=swap' rel='stylesheet'>
+        <style>* { font-family: "${GOOGLE_FONT}" !important; }</style>`,
         {
           html: true
         }


### PR DESCRIPTION
Hi @stephenou 

Here is a small update to handle font names such us "Space Mono", where it does need to be:
1) Converted to URL slug by replacing spaces by '+' 
2) Escaping CSS font name with double quotes to avoid space names.