### PR TITLE
Add query strings to proxy request

### DIFF
--- a/src/code.js
+++ b/src/code.js
@@ -115,7 +115,8 @@ ${slugs
       response.headers.set('content-type', 'application/xml');
       return response;
     }
-    const notionUrl = 'https://www.notion.so' + url.pathname;
+    let fullPathname = request.url.replace("https://" + MY_DOMAIN, "");
+    const notionUrl = 'https://www.notion.so' + fullPathname;
     let response;
     if (url.pathname.startsWith('/app') && url.pathname.endsWith('js')) {
       response = await fetch(notionUrl);


### PR DESCRIPTION
All the major sites that are using notion (super.so) with custom domains are currently down because of a change notion made to images they host. They now require query string identifiers at the end of the image request. The current code for your notionUrl doesn't account for that so I changed it.