### PR TITLE
Smart Light-Dark mode detection

### DIFF
--- a/worker.js
+++ b/worker.js
@@ -252,7 +252,18 @@ class BodyRewriter {
         el.className = 'toggle-mode';
         el.addEventListener('click', toggle);
         nav.appendChild(el);
-        onLight();
+
+        // enable smart dark mode basded on user-preference
+        if (window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches) {
+            onDark();
+        } else {
+            onLight();
+        }
+
+        // try to detect if user-preference change
+        window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', e => {
+            toggl();
+        });
       }
       const observer = new MutationObserver(function() {
         if (redirected) return;

--- a/worker.js
+++ b/worker.js
@@ -253,7 +253,7 @@ class BodyRewriter {
         el.addEventListener('click', toggle);
         nav.appendChild(el);
 
-        // enable smart dark mode basded on user-preference
+        // enable smart dark mode based on user-preference
         if (window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches) {
             onDark();
         } else {
@@ -262,7 +262,7 @@ class BodyRewriter {
 
         // try to detect if user-preference change
         window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', e => {
-            toggl();
+            toggle();
         });
       }
       const observer = new MutationObserver(function() {


### PR DESCRIPTION
# Use case
When user has already chosen a Dark Mode preference (ie macOS/iOS) and site start in white mode killing your eyes. This will make the site smart enough to detect that preference and switch the Dark Mode on.

Nothing critical changed.

# Next steps
Could be improved to let site author chose if they want to turn this feature on/off (based on style preferences).