### PR TITLE
Issue #58 : Update `getPage()` to have `.slice(1)`

### DIFF
--- a/worker.js
+++ b/worker.js
@@ -219,7 +219,7 @@ class BodyRewriter {
         PAGE_TO_SLUG[page] = slug;
       });
       function getPage() {
-        return location.pathname.slice(-32);
+        return location.pathname.slice(1);
       }
       function getSlug() {
         return location.pathname.slice(1);


### PR DESCRIPTION
Currently `getPage` returns `location.pathname.slice(-32)`
This causes `slug` to be not found when the pathname is longer