### PR TITLE
Dynamically set domainBaseURL

### DIFF
--- a/src/code.js
+++ b/src/code.js
@@ -211,7 +211,7 @@ ${slugs
     element(element) {
       element.append(\`<div style="display:none">Powered by <a href="http://fruitionsite.com">Fruition</a></div>
       <script>
-      window.CONFIG.domainBaseUrl = 'https://\${MY_DOMAIN}';
+      window.CONFIG.domainBaseUrl = location.origin;
       const SLUG_TO_PAGE = \${JSON.stringify(this.SLUG_TO_PAGE)};
       const PAGE_TO_SLUG = {};
       const slugs = [];

--- a/worker.js
+++ b/worker.js
@@ -211,7 +211,7 @@ class BodyRewriter {
   element(element) {
     element.append(
       `<script>
-      window.CONFIG.domainBaseUrl = 'https://${MY_DOMAIN}';
+      window.CONFIG.domainBaseUrl = location.origin;
       const SLUG_TO_PAGE = ${JSON.stringify(this.SLUG_TO_PAGE)};
       const PAGE_TO_SLUG = {};
       const slugs = [];


### PR DESCRIPTION
This changes the injected config to be set from the `window.location` instead of being hardcoded.

I think this could resolve config issues like #122 and #137.

This also means that it'll work on `*.workers.dev` domains and in the "Preview" panel in cloudflare:

<img width="400" alt="Screenshot 2021-10-12 at 14 06 47" src="https://user-images.githubusercontent.com/51385/136962017-7bbc1655-ed28-4cb5-9d61-fef63eec7e0e.png">
