### PR TITLE
Adding functionality to choose light theme as default or not

### DIFF
--- a/src/code.js
+++ b/src/code.js
@@ -50,6 +50,9 @@ ${slugs
   
   /* Step 5: enter any custom scripts you'd like */
   const CUSTOM_SCRIPT = \`${customScript || ''}\`;
+
+  /* Step 6: choose default theme (light by default) */
+  const LIGHT_THEME_BY_DEFAULT = true
   
   /* CONFIGURATION ENDS HERE */
   
@@ -258,7 +261,11 @@ ${slugs
         el.className = 'toggle-mode';
         el.addEventListener('click', toggle);
         nav.appendChild(el);
-        onLight();
+        if (\${LIGHT_THEME_BY_DEFAULT}) {
+          onLight();
+        } else {
+          onDark();
+        }
       }
       const observer = new MutationObserver(function() {
         if (redirected) return;


### PR DESCRIPTION
They say the best way to make a product is to look into your own life and see if that makes a difference. If it does build it. With this PR I hope I make Fruition a little better for everyone.

I had been looking for a way to show my fruition page show up in dark mode by default. So I went ahead and changed the `onLight()` call to `onDark()` call in the `addDarkModeButton()` function in the `BodyRewriter` class. Then I saw posts on Reddit and Issues that were trying to solve the same problem (#159). So I went ahead and made some changes as suggested.

I hope this helps :)

One again thank you for Fruition!