### PR TITLE
Temporary redirect (302) instead of permanent (301)

### DIFF
--- a/src/code.js
+++ b/src/code.js
@@ -138,7 +138,7 @@ ${slugs
       return response;
     } else if (slugs.indexOf(url.pathname.slice(1)) > -1) {
       const pageId = SLUG_TO_PAGE[url.pathname.slice(1)];
-      return Response.redirect('https://' + MY_DOMAIN + '/' + pageId, 301);
+      return Response.redirect('https://' + MY_DOMAIN + '/' + pageId, 302);
     } else {
       response = await fetch(url.toString(), {
         body: request.body,


### PR DESCRIPTION
I suggest to switch to temporary redirects, as the caching of permanent redirects by browsers can lead to unwanted behavior. It happened to me and other users of that project who I know that we changed a page (same slug, different Notion page id), but users who have visited the page continued to see the old page due to the cached 301 redirect.

Switching to 302 comes at the cost of an uncached redirect for returning users but at no cost for new users. As many use fruition for quickly moving projects/prototypes, I think switching to 302 makes sense to avoid the cached redirects.