### PR TITLE
Allow handling requests to exp.notion.so

### DIFF
--- a/worker.js
+++ b/worker.js
@@ -91,7 +91,7 @@ async function fetchAndApply(request) {
     let response = await fetch(url.toString(), {
       body: request.body,
       headers: request.headers,
-      method: request.method,
+      method: request.method
     });
     response = new Response(response.body, response);
     return response;

--- a/worker.js
+++ b/worker.js
@@ -55,8 +55,9 @@ function generateSitemap() {
 
 const corsHeaders = {
   "Access-Control-Allow-Origin": "*",
-  "Access-Control-Allow-Methods": "GET, HEAD, POST, PUT, OPTIONS",
-  "Access-Control-Allow-Headers": "Content-Type"
+  "Access-Control-Allow-Methods": "GET, HEAD, POST, PUT, OPTIONS, DELETE, PATCH",
+  "Access-Control-Allow-Headers": "Content-Type,statsig-api-key,statsig-client-time,statsig-encoded,statsig-sdk-type,statsig-sdk-version",
+  "Sec-Fetch-Site": "cross-site"
 };
 
 function handleOptions(request) {
@@ -73,7 +74,7 @@ function handleOptions(request) {
     // Handle standard OPTIONS request.
     return new Response(null, {
       headers: {
-        Allow: "GET, HEAD, POST, PUT, OPTIONS"
+        Allow: "GET, HEAD, POST, PUT, OPTIONS, DELETE, PATCH"
       }
     });
   }
@@ -84,61 +85,72 @@ async function fetchAndApply(request) {
     return handleOptions(request);
   }
   let url = new URL(request.url);
-  url.hostname = 'www.notion.so';
-  if (url.pathname === "/robots.txt") {
-    return new Response("Sitemap: https://" + MY_DOMAIN + "/sitemap.xml");
-  }
-  if (url.pathname === "/sitemap.xml") {
-    let response = new Response(generateSitemap());
-    response.headers.set("content-type", "application/xml");
-    return response;
-  }
-  let response;
-  if (url.pathname.startsWith("/app") && url.pathname.endsWith("js")) {
-    response = await fetch(url.toString());
-    let body = await response.text();
-    response = new Response(
-      body
-        .replace(/www.notion.so/g, MY_DOMAIN)
-        .replace(/notion.so/g, MY_DOMAIN),
-      response
-    );
-    response.headers.set("Content-Type", "application/x-javascript");
-    return response;
-  } else if (url.pathname.startsWith("/api")) {
-    // Forward API
-    response = await fetch(url.toString(), {
-      body: url.pathname.startsWith('/api/v3/getPublicPageData') ? null : request.body,
-      headers: {
-        "content-type": "application/json;charset=UTF-8",
-        "user-agent":
-          "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.163 Safari/537.36"
-      },
-      method: "POST"
-    });
-    response = new Response(response.body, response);
-    response.headers.set("Access-Control-Allow-Origin", "*");
-    return response;
-  } else if (slugs.indexOf(url.pathname.slice(1)) > -1) {
-    const pageId = SLUG_TO_PAGE[url.pathname.slice(1)];
-    return Response.redirect("https://" + MY_DOMAIN + "/" + pageId, 301);
-  } else if (
-    pages.indexOf(url.pathname.slice(1)) === -1 &&
-    url.pathname.slice(1).match(/[0-9a-f]{32}/)
-  ) {
-    return Response.redirect('https://' + MY_DOMAIN, 301);
-  } else {
-    response = await fetch(url.toString(), {
+  // Check if the subdomain is 'exp'
+  if (url.hostname.startsWith('exp.')) {
+    url.hostname = 'exp.notion.so';
+    let response = await fetch(url.toString(), {
       body: request.body,
       headers: request.headers,
-      method: request.method
+      method: request.method,
     });
     response = new Response(response.body, response);
-    response.headers.delete("Content-Security-Policy");
-    response.headers.delete("X-Content-Security-Policy");
+    return response;
+  } else {
+    url.hostname = 'www.notion.so';
+    if (url.pathname === "/robots.txt") {
+      return new Response("Sitemap: https://" + MY_DOMAIN + "/sitemap.xml");
+    }
+    if (url.pathname === "/sitemap.xml") {
+      let response = new Response(generateSitemap());
+      response.headers.set("content-type", "application/xml");
+      return response;
+    }
+    let response;
+    if (url.pathname.startsWith("/app") && url.pathname.endsWith("js")) {
+      response = await fetch(url.toString());
+      let body = await response.text();
+      response = new Response(
+        body
+          .replace(/www.notion.so/g, MY_DOMAIN)
+          .replace(/notion.so/g, MY_DOMAIN),
+        response
+      );
+      response.headers.set("Content-Type", "application/x-javascript");
+      return response;
+    } else if (url.pathname.startsWith("/api")) {
+      // Forward API
+      response = await fetch(url.toString(), {
+        body: url.pathname.startsWith('/api/v3/getPublicPageData') ? null : request.body,
+        headers: {
+          "content-type": "application/json;charset=UTF-8",
+          "user-agent":
+            "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.163 Safari/537.36"
+        },
+        method: "POST"
+      });
+      response = new Response(response.body, response);
+      response.headers.set("Access-Control-Allow-Origin", "*");
+      return response;
+    } else if (slugs.indexOf(url.pathname.slice(1)) > -1) {
+      const pageId = SLUG_TO_PAGE[url.pathname.slice(1)];
+      return Response.redirect("https://" + MY_DOMAIN + "/" + pageId, 301);
+    } else if (
+      pages.indexOf(url.pathname.slice(1)) === -1 &&
+      url.pathname.slice(1).match(/[0-9a-f]{32}/)
+    ) {
+      return Response.redirect('https://' + MY_DOMAIN, 301);
+    } else {
+      response = await fetch(url.toString(), {
+        body: request.body,
+        headers: request.headers,
+        method: request.method
+      });
+      response = new Response(response.body, response);
+      response.headers.delete("Content-Security-Policy");
+      response.headers.delete("X-Content-Security-Policy");
+    }
+    return appendJavascript(response, SLUG_TO_PAGE);
   }
-
-  return appendJavascript(response, SLUG_TO_PAGE);
 }
 
 class MetaRewriter {


### PR DESCRIPTION
I don't know if it's needed, but the browser goes crazy trying to fetch content from `exp.MY_DOMAIN` so I'd though I'd let it have it.

Modifying the headers like I did didn't break anything, but I simply tested one Notion page. It might be best for it to be tested with several other pages before approving it.

_PS: The values for `Access-Control-Allow-Headers` and `Access-Control-Allow-Methods` are not random, they are the ones I saw being sent while checking the requests on a Notion site accessed the "normal" way (without the worker)._